### PR TITLE
[40][220723] Fixed the data stream flow infinite loop bug

### DIFF
--- a/app/src/main/java/mz/co/bilheteira/statemachine/di/MiddlewareModule.kt
+++ b/app/src/main/java/mz/co/bilheteira/statemachine/di/MiddlewareModule.kt
@@ -5,7 +5,7 @@ import dagger.Module
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import mz.co.bilheteira.statemachine.ui.search.statemanager.SearchAction
-import mz.co.bilheteira.statemachine.ui.search.statemanager.SearchMiddleware
+import mz.co.bilheteira.statemachine.ui.search.statemanager.SearchNetworkingMiddleware
 import mz.co.bilheteira.statemachine.ui.search.statemanager.SearchViewState
 import mz.co.bilheteira.statemanager.Middleware
 
@@ -15,6 +15,6 @@ internal abstract class MiddlewareModule {
 
     @Binds
     abstract fun bindsMiddleware(
-        searchMiddleware: SearchMiddleware,
+        searchNetworkingMiddleware: SearchNetworkingMiddleware,
     ): Middleware<SearchViewState, SearchAction>
 }

--- a/app/src/main/java/mz/co/bilheteira/statemachine/ui/search/SearchScreenRoute.kt
+++ b/app/src/main/java/mz/co/bilheteira/statemachine/ui/search/SearchScreenRoute.kt
@@ -19,7 +19,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.modifier.modifierLocalConsumer
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -48,8 +47,13 @@ internal fun SearchContent(
     viewState: SearchViewState,
 ) {
     when (viewState) {
-        is SearchViewState.Loading -> CircularProgressBar(
-            isLoading = viewState.isLoading,
+        SearchViewState.Loading -> CircularProgressBar(
+            isLoading = true,
+            modifier = modifier,
+        )
+
+        SearchViewState.Success -> CircularProgressBar(
+            isLoading = false,
             modifier = modifier,
         )
 
@@ -63,6 +67,8 @@ internal fun SearchContent(
             modifier = modifier,
             message = viewState.message,
         )
+
+        else -> {}
     }
 }
 

--- a/app/src/main/java/mz/co/bilheteira/statemachine/ui/search/SearchViewModel.kt
+++ b/app/src/main/java/mz/co/bilheteira/statemachine/ui/search/SearchViewModel.kt
@@ -22,7 +22,8 @@ internal class SearchViewModel @Inject constructor(
 
     private fun fetchLocations() {
         viewModelScope.launch {
-            searchStore.dispatch(SearchAction.FetchLocations)
+            val newAction = SearchAction.FetchLocations
+            searchStore.dispatch(action = newAction)
         }
     }
 }

--- a/app/src/main/java/mz/co/bilheteira/statemachine/ui/search/statemanager/SearchAction.kt
+++ b/app/src/main/java/mz/co/bilheteira/statemachine/ui/search/statemanager/SearchAction.kt
@@ -10,7 +10,9 @@ internal sealed class SearchAction : Action {
     object FetchLocations : SearchAction()
     object FetchingLocations : SearchAction()
 
-    data class LocationContent(
+    object FetchingLocationsDone : SearchAction()
+
+    data class LocationsLoaded(
         val locations: List<LocationModel>
     ) : SearchAction()
 

--- a/app/src/main/java/mz/co/bilheteira/statemachine/ui/search/statemanager/SearchNetworkingMiddleware.kt
+++ b/app/src/main/java/mz/co/bilheteira/statemachine/ui/search/statemanager/SearchNetworkingMiddleware.kt
@@ -9,7 +9,7 @@ import javax.inject.Inject
  * This is a custom [Middleware] that processes any [SearchAction]s and triggers a
  * corresponding data request to our [repository] if necessary.
  */
-internal class SearchMiddleware @Inject constructor(
+internal class SearchNetworkingMiddleware @Inject constructor(
     private val repository: Repository
 ) : Middleware<SearchViewState, SearchAction> {
     override suspend fun process(
@@ -18,16 +18,16 @@ internal class SearchMiddleware @Inject constructor(
         store: Store<SearchViewState, SearchAction>
     ) {
         when (action) {
-            SearchAction.FetchLocations -> fetchLocations(store)
-            is SearchAction.Error -> store.dispatch(SearchAction.Error(message = action.message))
-            else -> store.dispatch(action)
+            SearchAction.FetchLocations -> fetchRemoteStoredLocations(store)
+            else -> {}
         }
     }
 
-    private suspend fun fetchLocations(searchStore: Store<SearchViewState, SearchAction>) {
-        searchStore.dispatch(SearchAction.FetchingLocations)
+    private suspend fun fetchRemoteStoredLocations(store: Store<SearchViewState, SearchAction>) {
+        store.dispatch(SearchAction.FetchingLocations)
         repository.getLocations().collect { locations ->
-            searchStore.dispatch(SearchAction.LocationContent(locations = locations))
+            store.dispatch(SearchAction.FetchingLocationsDone)
+            store.dispatch(SearchAction.LocationsLoaded(locations = locations))
         }
     }
 }

--- a/app/src/main/java/mz/co/bilheteira/statemachine/ui/search/statemanager/SearchReducer.kt
+++ b/app/src/main/java/mz/co/bilheteira/statemachine/ui/search/statemanager/SearchReducer.kt
@@ -11,14 +11,16 @@ internal class SearchReducer : Reducer<SearchViewState, SearchAction> {
     override fun reduce(currentState: SearchViewState, action: SearchAction): SearchViewState {
         return when (action) {
             SearchAction.FetchingLocations -> newStateWhileFetchingLocations()
+            SearchAction.FetchingLocationsDone -> newStateAfterFetchingLocations()
             is SearchAction.Error -> newStateWithError(message = action.message)
-            is SearchAction.LocationContent -> newStateWithLocationContent(locations = action.locations)
+            is SearchAction.LocationsLoaded -> newStateWithLocationContent(locations = action.locations)
             else -> currentState
         }
     }
 
-    private fun newStateWhileFetchingLocations(): SearchViewState =
-        SearchViewState.Loading(isLoading = true)
+    private fun newStateWhileFetchingLocations(): SearchViewState = SearchViewState.Loading
+
+    private fun newStateAfterFetchingLocations(): SearchViewState = SearchViewState.Success
 
     private fun newStateWithError(
         message: String

--- a/app/src/main/java/mz/co/bilheteira/statemachine/ui/search/statemanager/SearchStore.kt
+++ b/app/src/main/java/mz/co/bilheteira/statemachine/ui/search/statemanager/SearchStore.kt
@@ -10,9 +10,9 @@ import javax.inject.Inject
 internal class SearchStore @Inject constructor(
     repository: Repository
 ) : BaseStore<SearchViewState, SearchAction>(
-    initialState = SearchViewState.Loading(isLoading = false),
+    initialState = SearchViewState.Initial,
     reducer = SearchReducer(),
     middlewares = listOf(
-        SearchMiddleware(repository = repository),
+        SearchNetworkingMiddleware(repository = repository),
     )
 )

--- a/app/src/main/java/mz/co/bilheteira/statemachine/ui/search/statemanager/SearchViewState.kt
+++ b/app/src/main/java/mz/co/bilheteira/statemachine/ui/search/statemanager/SearchViewState.kt
@@ -1,6 +1,5 @@
 package mz.co.bilheteira.statemachine.ui.search.statemanager
 
-import kotlinx.coroutines.flow.Flow
 import mz.co.bilheteira.domain.data.LocationModel
 import mz.co.bilheteira.statemanager.State
 
@@ -8,9 +7,11 @@ import mz.co.bilheteira.statemanager.State
  * Configuration of different UI States of the Search screen
  */
 sealed class SearchViewState : State {
-    data class Loading(
-        val isLoading: Boolean = false
-    ) : SearchViewState()
+    object Initial : SearchViewState()
+
+    object Loading : SearchViewState()
+
+    object Success : SearchViewState()
 
     data class Error(
         val message: String

--- a/state-manager/src/main/java/mz/co/bilheteira/statemanager/BaseStore.kt
+++ b/state-manager/src/main/java/mz/co/bilheteira/statemanager/BaseStore.kt
@@ -1,6 +1,5 @@
 package mz.co.bilheteira.statemanager
 
-import android.util.Log
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 


### PR DESCRIPTION
This PR aims to resolve a risk of stream running on infinite loop (which ended up happening) 😄

So basically, what was happening is that because the store loops throughout all the possible middleware and those have to dispatch next action back to store, and when those where trying to process all the possible actions, it was causing some concurrent calls which led to infinite loop.

**Something to note**: Middleware don't have to process/handle all possible actions of the screen/view