### PR TITLE
[260723] Migrate to KSP

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.hilt)
+    alias(libs.plugins.ksp)
     kotlin("kapt")
 }
 
@@ -45,7 +46,7 @@ android {
         compose = true
     }
     composeOptions {
-        kotlinCompilerExtensionVersion = "1.4.8"
+        kotlinCompilerExtensionVersion = "1.5.1"
     }
     packaging {
         resources {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,4 +10,5 @@ plugins {
     alias(libs.plugins.android.library) apply false
     alias(libs.plugins.kotlin.android) apply false
     alias(libs.plugins.hilt) apply false
+    alias(libs.plugins.ksp) apply false
 }

--- a/domain/build.gradle.kts
+++ b/domain/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
     alias(libs.plugins.android.library)
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.hilt)
+    alias(libs.plugins.ksp)
     kotlin("kapt")
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,6 +18,7 @@ room = "2.5.2"
 moshi = "1.14.0"
 retofit = "2.9.0"
 logging-interceptor = "4.10.0"
+ksp = "1.9.0-1.0.12"
 
 [libraries]
 compose-ui = { module = "androidx.compose.ui:ui", version.ref = "compose" }
@@ -101,3 +102,4 @@ hilt = { id = "com.google.dagger.hilt.android", version.ref = "hilt" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 android-library = { id = "com.android.library", version = "8.0.2" }
 android-application = { id = "com.android.application", version = "8.0.2" }
+ksp = { id = "com.google.devtools.ksp", version.ref = "ksp"}

--- a/network/build.gradle.kts
+++ b/network/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
     alias(libs.plugins.android.library)
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.hilt)
+    alias(libs.plugins.ksp)
     kotlin("kapt")
 }
 
@@ -31,9 +32,8 @@ dependencies {
 
     api(libs.bundles.retrofit)
 
-    implementation(libs.moshi)
-    implementation(libs.moshi.adapters)
-    kapt(libs.moshi.codegen)
+    implementation(libs.bundles.moshi)
+    ksp(libs.moshi.codegen)
 
     testImplementation(libs.bundles.test)
 }

--- a/storage/build.gradle.kts
+++ b/storage/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
     alias(libs.plugins.android.library)
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.hilt)
+    alias(libs.plugins.ksp)
     kotlin("kapt")
 }
 
@@ -25,7 +26,7 @@ android {
 
 dependencies {
     implementation(libs.bundles.room)
-    kapt(libs.room.compiler)
+    ksp(libs.room.compiler)
 
     implementation(libs.hilt)
     kapt(libs.hilt.compiler)

--- a/storage/src/main/java/mz/co/bilheteira/storage/LocationDatabase.kt
+++ b/storage/src/main/java/mz/co/bilheteira/storage/LocationDatabase.kt
@@ -5,7 +5,7 @@ import androidx.room.RoomDatabase
 import mz.co.bilheteira.storage.dao.LocationDao
 import mz.co.bilheteira.storage.entity.LocationEntity
 
-@Database(entities = [LocationEntity::class], version = 1)
+@Database(entities = [LocationEntity::class], version = 1, exportSchema = false)
 abstract class LocationDatabase : RoomDatabase() {
 
     abstract fun getLocationDao(): LocationDao


### PR DESCRIPTION
In this PR, I have added support for KSP which has better performance over KAPT.

Although this is good on Kotlin projects, not all popular libraries do support KSP. Dagger-Hilt for instance, is still working to have KSP support.

So here, KSP is being used at the same time with KAPT, so we won't see that performance improvements until we have completely removed KAPT.
